### PR TITLE
add onLeft and leftTitle to match onRight, rightTitle

### DIFF
--- a/ExRouter.js
+++ b/ExRouter.js
@@ -86,6 +86,16 @@ export class ExRouteAdapter {
     }
 
     renderLeftButton(navigator, index, state){
+        if (this.route.props.onLeft && this.route.props.leftTitle) {
+            return (<TouchableOpacity
+              touchRetentionOffset={ExNavigator.Styles.barButtonTouchRetentionOffset}
+              onPress={() => this.route.props.onLeft({...this.route.props, ...this.props})}
+              style={[ExNavigator.Styles.barLeftButton, this.route.props.leftButtonStyle]}>
+                <Text
+                  style={[ExNavigator.Styles.barLeftButtonText, this.route.props.leftButtonTextStyle]}>{this.route.props.leftTitle}</Text>
+            </TouchableOpacity>);
+        }
+        
         if (index === 0 || index < navigator.getCurrentRoutes().length-1) {
             return null;
         }


### PR DESCRIPTION
Is there a particular reason we allow the right button to be easily customized, but don't provide the same Route props for the left button?
